### PR TITLE
Remove explicit dependency deps and source from plotting_scripts/Proj…

### DIFF
--- a/plotting_scripts/Project.toml
+++ b/plotting_scripts/Project.toml
@@ -1,14 +1,8 @@
 [deps]
-FiniteElementMatrices = "21a267ae-cf5f-40e4-86cc-2968ca96a734"
 FokkerPlanck = "6a6b5c72-6869-4c05-b853-2893d318cc38"
-JacobianFreeNewtonKrylov = "ea74541f-29a8-443c-83cd-bcc24bd49708"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-LagrangePolynomials = "fb83b288-ce1a-45f4-939e-c34c34051e49"
 Measures = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [sources]
-FiniteElementMatrices = {url = "https://github.com/moment-kinetics/FiniteElementMatrices"}
 FokkerPlanck = {path = "../"}
-JacobianFreeNewtonKrylov = {url = "https://github.com/moment-kinetics/JacobianFreeNewtonKrylov"}
-LagrangePolynomials = {url = "https://github.com/moment-kinetics/LagrangePolynomials"}


### PR DESCRIPTION
…ect.toml to avoid having to record version and location information in two places.