### PR TITLE
Improve interface

### DIFF
--- a/plotting_scripts/2D_FEM_assembly_test.jl
+++ b/plotting_scripts/2D_FEM_assembly_test.jl
@@ -73,7 +73,6 @@ end
         algebraic_solve_for_d2Gdvperp2=false,
         boundary_data_option=direct_integration)
         
-        bc = "none"
         element_spacing_option = "uniform"
         println("made inputs")
         println("vpa: ngrid: ",ngrid," nelement: ",nelement_vpa, " Lvpa: ",Lvpa)
@@ -82,13 +81,11 @@ end
         vperp = finite_element_coordinate("vperp", scalar_coordinate_inputs(ngrid,
                                     nelement_vperp,
                                     Lvperp),
-                                    element_spacing_option=element_spacing_option,
-                                    bc=bc)
+                                    element_spacing_option=element_spacing_option)
         vpa = finite_element_coordinate("vpa", scalar_coordinate_inputs(ngrid,
                                     nelement_vpa,
                                     Lvpa),
-                                    element_spacing_option=element_spacing_option,
-                                    bc=bc)
+                                    element_spacing_option=element_spacing_option)
         nc_global = vpa.n*vperp.n
         start_init_time = now()
         fkpl_arrays = fokkerplanck_weakform_arrays_struct(vpa,vperp,boundary_data_option)

--- a/plotting_scripts/fkpl_direct_integration_test.jl
+++ b/plotting_scripts/fkpl_direct_integration_test.jl
@@ -57,20 +57,17 @@ function init_grids(nelement,ngrid)
     # define inputs needed for the test
     Lvpa = 12.0 #physical box size in reference units 
     Lvperp = 6.0 #physical box size in reference units 
-    bc = "zero" 
     
     element_spacing_option = "uniform"
     # create the coordinate structs
     vperp = finite_element_coordinate("vperp", scalar_coordinate_inputs(ngrid,
                                 nelement,
                                 Lvperp),
-                                element_spacing_option=element_spacing_option,
-                                bc=bc)
+                                element_spacing_option=element_spacing_option)
     vpa = finite_element_coordinate("vpa", scalar_coordinate_inputs(ngrid,
                                 nelement,
                                 Lvpa),
-                                element_spacing_option=element_spacing_option,
-                                bc=bc)
+                                element_spacing_option=element_spacing_option)
     return vpa, vperp
 end
 

--- a/src/FokkerPlanck.jl
+++ b/src/FokkerPlanck.jl
@@ -105,7 +105,7 @@ end
 function fokker_planck_self_collision_operator_weak_form!(
                          pdf_in::AbstractArray{mk_float,2}, ms::mk_float, nuss::mk_float,
                          fkpl_arrays::fokkerplanck_weakform_arrays_struct;
-                         use_conserving_corrections=false::Bool)
+                         use_conserving_corrections=true::Bool)
     # first argument is Fs, and second argument is Fs' in C[Fs,Fs'] 
     @views fokker_planck_collision_operator_weak_form!(
         pdf_in, pdf_in, ms, ms, nuss, fkpl_arrays)
@@ -351,7 +351,7 @@ end
 function fokker_planck_self_collisions_backward_euler_step!(Fold::AbstractArray{mk_float,2},
                         delta_t::mk_float, ms::mk_float, nuss::mk_float,
                         fkpl_arrays::fokkerplanck_weakform_arrays_struct;
-                        test_numerical_conserving_terms=false::Bool,
+                        use_conserving_corrections=true::Bool,
                         test_linearised_advance=false::Bool,
                         test_particle_preconditioner=true::Bool,
                         use_Maxwellian_Rosenbluth_coefficients_in_preconditioner=false::Bool)
@@ -365,7 +365,7 @@ function fokker_planck_self_collisions_backward_euler_step!(Fold::AbstractArray{
         fokker_planck_self_collision_operator_weak_form!(
                         Fnew, ms, nuss,
                         fkpl_arrays; 
-                        use_conserving_corrections=test_numerical_conserving_terms)
+                        use_conserving_corrections=use_conserving_corrections)
 
         @inbounds begin
             for ivperp in 1:vperp.n
@@ -422,7 +422,7 @@ function fokker_planck_self_collisions_backward_euler_step!(Fold::AbstractArray{
         # apply BCs on result, if non-natural BCs are imposed
         # should only introduce error of order ~ atol
         enforce_vpavperp_BCs!(Fnew,vpa,vperp)
-        if test_numerical_conserving_terms
+        if use_conserving_corrections
             # ad-hoc end-of-step corrections, again introducing only ~atol error
             deltaF = fkpl_arrays.rhsvpavperp
             @inbounds begin

--- a/src/FokkerPlanck.jl
+++ b/src/FokkerPlanck.jl
@@ -45,7 +45,10 @@ using Dates
 using LinearAlgebra: lu, ldiv!
 using ..type_definitions: mk_float, mk_int
 using ..array_allocation: allocate_float
-using ..coordinates: finite_element_coordinate, scalar_coordinate_inputs
+using ..coordinates: finite_element_coordinate,
+                    scalar_coordinate_inputs,
+                    finite_element_boundary_condition_type,
+                    natural_boundary_condition, zero_boundary_condition
 using ..velocity_moments: get_density
 using ..fokker_planck_calculus: fokkerplanck_weakform_arrays_struct,
                                 assemble_explicit_collision_operator_rhs_serial!,
@@ -78,8 +81,8 @@ and the latterr is defined in `FiniteElementMatrices`.
 function init_fokker_planck_collisions(
     inputs_vpa::Union{scalar_coordinate_inputs,Array{element_coordinates,1}},
     inputs_vperp::Union{scalar_coordinate_inputs,Array{element_coordinates,1}};
-    bc_vpa="none"::String,
-    bc_vperp="none"::String,
+    bc_vpa=natural_boundary_condition::finite_element_boundary_condition_type,
+    bc_vperp=natural_boundary_condition::finite_element_boundary_condition_type,
     boundary_data_option=multipole_expansion::boundary_data_type,
     nl_solver_atol=1.0e-10::mk_float,
     nl_solver_rtol=0.0::mk_float,

--- a/src/coordinates.jl
+++ b/src/coordinates.jl
@@ -154,6 +154,17 @@ struct scalar_coordinate_inputs
 end
 
 """
+enum for boundary conditions imposed
+on the evolved solution.
+"""
+@enum finite_element_boundary_condition_type begin
+    # boundary condition imposed by structure of FE matrices
+    natural_boundary_condition
+    # Zero boundary conditions are imposed on the FE matrices and the solution
+    zero_boundary_condition
+end
+
+"""
 structure containing basic information related to coordinates
 """
 struct finite_element_coordinate
@@ -180,7 +191,7 @@ struct finite_element_coordinate
     # igrid_full[i,j] contains the index of the full grid for the elemental grid point i, on element j
     igrid_full::Array{mk_int,2}
     # bc is the boundary condition option for this coordinate
-    bc::String
+    bc::finite_element_boundary_condition_type
     # wgts contains the integration weights associated with each grid point
     wgts::Array{mk_float,1}
     # scale for each element
@@ -208,7 +219,7 @@ struct finite_element_coordinate
         # option for spacing between element boundaries
         element_spacing_option="uniform"::String,
         # which boundary condition to use
-        bc="none"::String)
+        bc=natural_boundary_condition::finite_element_boundary_condition_type)
         ngrid = scalar_input.ngrid
         nelement = scalar_input.nelement
         Ldomain = scalar_input.Ldomain
@@ -256,7 +267,7 @@ struct finite_element_coordinate
         # from which the coordinate struct can be created
         element_data::Union{Array{element_coordinates,1},Nothing};
         # which boundary condition to use
-        bc="none"::String)
+        bc=natural_boundary_condition::finite_element_boundary_condition_type)
         if typeof(element_data) == Nothing
             # this is a trivial coordinate of length 1
             nelement = 1

--- a/src/fokker_planck_calculus.jl
+++ b/src/fokker_planck_calculus.jl
@@ -2011,8 +2011,9 @@ without allocation. Use the exact results for the part of F that can be describe
 a Maxwellian, and the multipole expansion for the remainder.
 """
 function calculate_rosenbluth_potential_boundary_data_delta_f_multipole!(rpbd::rosenbluth_potential_boundary_data,
-    pdf::Tpdf,dummy_vpavperp::Tpdf,vpa::finite_element_coordinate,vperp::finite_element_coordinate;
-    calculate_GG=false,calculate_dGdvperp=false) where Tpdf <: AbstractArray{mk_float,2}
+    pdf::AbstractArray{mk_float,2},dummy_vpavperp::AbstractArray{mk_float,2},
+    vpa::finite_element_coordinate,vperp::finite_element_coordinate;
+    calculate_GG=false,calculate_dGdvperp=false)
 
     mass = 1.0
     dens = get_density(pdf, vpa, vperp)
@@ -2632,7 +2633,7 @@ in weak form. Once the array `rhsvpavperp` contains the assembled weak-form coll
 a mass matrix solve still must be carried out to find the time derivative of the distribution function
 due to collisions.
 """
-function assemble_explicit_collision_operator_rhs_serial!(rhsvpavperp::Tpdf,pdfs::Tpdf,
+function assemble_explicit_collision_operator_rhs_serial!(rhsvpavperp::Tpdf,pdfs::AbstractArray{mk_float,2},
     d2Gspdvpa2::Tpdf,d2Gspdvperpdvpa::Tpdf,d2Gspdvperp2::Tpdf,
     dHspdvpa::Tpdf,dHspdvperp::Tpdf,ms::mk_float,msp::mk_float,nussp::mk_float,
     vpa::finite_element_coordinate,vperp::finite_element_coordinate,
@@ -2830,7 +2831,7 @@ to solve the PDE matrix equations.
 """
 function calculate_rosenbluth_potentials_via_elliptic_solve!(GG::Tpdf,
              HH::Tpdf,dHdvpa::Tpdf,dHdvperp::Tpdf,d2Gdvpa2::Tpdf,dGdvperp::Tpdf,
-             d2Gdvperpdvpa::Tpdf,d2Gdvperp2::Tpdf,ffsp_in::Tpdf,
+             d2Gdvperpdvpa::Tpdf,d2Gdvperp2::Tpdf,ffsp_in::AbstractArray{mk_float,2},
              vpa::finite_element_coordinate,vperp::finite_element_coordinate,
              fkpl_arrays::fokkerplanck_weakform_arrays_struct;
              algebraic_solve_for_d2Gdvperp2=false,calculate_GG=false,

--- a/test/ImplicitCollisionsTest.jl
+++ b/test/ImplicitCollisionsTest.jl
@@ -94,7 +94,7 @@ function test_implicit_collisions(;
     for it in 1:ntime
         # use Fold = F^n to obtain Fnew = F^n+1 for n = it 
         fokker_planck_self_collisions_backward_euler_step!(Fold, delta_t, ms, nuss, fkpl_arrays,
-            test_numerical_conserving_terms=test_numerical_conserving_terms,
+            use_conserving_corrections=test_numerical_conserving_terms,
             test_particle_preconditioner=test_particle_preconditioner,
             test_linearised_advance=test_linearised_advance,
             use_Maxwellian_Rosenbluth_coefficients_in_preconditioner=use_Maxwellian_Rosenbluth_coefficients_in_preconditioner)

--- a/test/ImplicitCollisionsTest.jl
+++ b/test/ImplicitCollisionsTest.jl
@@ -16,7 +16,8 @@ function test_implicit_collisions(;
     ngrid=3::mk_int, nelement_vpa=8::mk_int, nelement_vperp=4::mk_int,
     Lvpa=6.0::mk_float, Lvperp=3.0::mk_float,
     # boundary condition info
-    bc_vpa="none"::String, bc_vperp="none"::String,
+    bc_vpa=natural_boundary_condition::finite_element_boundary_condition_type,
+    bc_vperp=natural_boundary_condition::finite_element_boundary_condition_type,
     # time advance info
     ntime=1::mk_int,delta_t=1.0::mk_float,
     # nonlinear solver options
@@ -138,10 +139,12 @@ if abspath(PROGRAM_FILE) == @__FILE__
     Pkg.activate(".")
     # run once to precompile
     test_implicit_collisions(test_particle_preconditioner=true,test_numerical_conserving_terms=true,
-    vth0=0.5,vperp0=1.0,vpa0=1.0, nelement_vpa=4,nelement_vperp=2,Lvpa=8.0,Lvperp=4.0, bc_vpa="none", bc_vperp="none",
-     ntime=1, delta_t = 1.0, ngrid=5, test_linearised_advance=false)
+        vth0=0.5,vperp0=1.0,vpa0=1.0, nelement_vpa=4,nelement_vperp=2,Lvpa=8.0,Lvperp=4.0,
+        bc_vpa=natural_boundary_condition, bc_vperp=natural_boundary_condition,
+        ntime=1, delta_t = 1.0, ngrid=5, test_linearised_advance=false)
     # run a standard case now we are precompiled
     test_implicit_collisions(test_particle_preconditioner=true,test_numerical_conserving_terms=true,
-    vth0=0.5,vperp0=1.0,vpa0=1.0, nelement_vpa=32,nelement_vperp=16,Lvpa=8.0,Lvperp=4.0, bc_vpa="none", bc_vperp="none",
-     ntime=100, delta_t = 1.0, ngrid=5, test_linearised_advance=false)
+        vth0=0.5,vperp0=1.0,vpa0=1.0, nelement_vpa=32,nelement_vperp=16,Lvpa=8.0,Lvperp=4.0,
+        bc_vpa=natural_boundary_condition, bc_vperp=natural_boundary_condition,
+        ntime=100, delta_t = 1.0, ngrid=5, test_linearised_advance=false)
 end

--- a/test/ImplicitCollisionsTest.jl
+++ b/test/ImplicitCollisionsTest.jl
@@ -30,7 +30,9 @@ function test_implicit_collisions(;
     test_external_chebyshev_grid=false::Bool,
     print_diagnostics=true::Bool, print_timing=true::Bool,
     # if ci test, return initial and final pdfs for regression testing
-    continuous_integration_test=false::Bool)
+    continuous_integration_test=false::Bool,
+    # if external user, may pass a slice of an array into functions
+    test_input_array_type=false::Bool)
     
     start_init_time = now()
     # group integer inputs using `scalar_coordinate_inputs` from FokkerPlanck.coordinates
@@ -60,7 +62,12 @@ function test_implicit_collisions(;
     vpa = fkpl_arrays.vpa
     vperp = fkpl_arrays.vperp
     # arrays needed for advance
-    Fold = allocate_float(vpa.n,vperp.n)
+    if test_input_array_type
+        Fgeneral = allocate_float(vpa.n,vperp.n,1,1,1)
+        @views Fold = Fgeneral[:,:,1,1,1]
+    else
+        Fold = allocate_float(vpa.n,vperp.n)
+    end
     # dummy arrays needed for diagnostics
     Fout = allocate_float(vpa.n,vperp.n,2)
     Fdummy1 = allocate_float(vpa.n,vperp.n)

--- a/test/ImplicitCollisionsTestBase.jl
+++ b/test/ImplicitCollisionsTestBase.jl
@@ -1,7 +1,12 @@
 using FokkerPlanck.array_allocation: allocate_float
 using FokkerPlanck.type_definitions: mk_float, mk_int
 using FokkerPlanck: calculate_entropy_production
-using FokkerPlanck.coordinates: scalar_coordinate_inputs, set_element_boundaries, set_element_scale_and_shift, finite_element_coordinate
+using FokkerPlanck.coordinates: scalar_coordinate_inputs,
+                            set_element_boundaries,
+                            set_element_scale_and_shift,
+                            finite_element_coordinate,
+                            finite_element_boundary_condition_type,
+                            zero_boundary_condition, natural_boundary_condition
 using FokkerPlanck.fokker_planck_test: F_Maxwellian, F_Beam, print_test_data
 using FokkerPlanck.velocity_moments: get_density, get_upar, get_pressure, get_ppar, get_qpar, get_rmom
 using FiniteElementMatrices: element_coordinates
@@ -42,11 +47,11 @@ function diagnose_F_Maxwellian(pdf::AbstractArray{mk_float,2},
     println("rmom: ", rmom)
     dSdt = calculate_entropy_production(pdf,fkpl_arrays)
     println("dSdt: ", dSdt)
-    if vpa.bc == "zero"
+    if vpa.bc == zero_boundary_condition
         println("test vpa bc: F[1, :]", pdf[1, :])
         println("test vpa bc: F[end, :]", pdf[end, :])
     end
-    if vperp.bc == "zero"
+    if vperp.bc == zero_boundary_condition
         println("test vperp bc: F[:, end]", pdf[:, end])
     end
 end
@@ -109,13 +114,13 @@ function set_initial_pdf!(Fold::AbstractArray{mk_float,2},
             end
         end
     end
-    if vpa.bc == "zero"
+    if vpa.bc == zero_boundary_condition
         @inbounds for ivperp in 1:vperp.n
             Fold[1,ivperp] = 0.0
             Fold[end,ivperp] = 0.0
         end
     end
-    if vperp.bc == "zero"
+    if vperp.bc == zero_boundary_condition
         @inbounds for ivpa in 1:vpa.n
             Fold[ivpa,end] = 0.0
         end

--- a/test/ImplicitCollisionsTestCI.jl
+++ b/test/ImplicitCollisionsTestCI.jl
@@ -76,7 +76,7 @@ atol = 1.0e-13
         println("    - test Gauss Legendre")
         for test_input_array_type in (true,false)
             output_pdf_and_grid = test_implicit_collisions(test_particle_preconditioner=true,test_numerical_conserving_terms=true,
-            vth0=0.5,vperp0=1.0,vpa0=0.1, nelement_vpa=6,nelement_vperp=3,Lvpa=8.0,Lvperp=4.0, bc_vpa="none", bc_vperp="none",
+            vth0=0.5,vperp0=1.0,vpa0=0.1, nelement_vpa=6,nelement_vperp=3,Lvpa=8.0,Lvperp=4.0, bc_vpa=natural_boundary_condition, bc_vperp=natural_boundary_condition,
                 ntime=50, delta_t = 1.0, ngrid=3, test_linearised_advance=false, print_diagnostics=false, print_timing=false,
                 test_external_chebyshev_grid=false, continuous_integration_test=true,
                 test_input_array_type=test_input_array_type)
@@ -90,7 +90,7 @@ atol = 1.0e-13
     @testset "Gauss Chebyshev" begin
         println("    - test Gauss Chebyshev")
         output_pdf_and_grid = test_implicit_collisions(test_particle_preconditioner=true,test_numerical_conserving_terms=true,
-           vth0=0.5,vperp0=1.0,vpa0=0.1, nelement_vpa=6,nelement_vperp=3,Lvpa=8.0,Lvperp=4.0, bc_vpa="none", bc_vperp="none",
+           vth0=0.5,vperp0=1.0,vpa0=0.1, nelement_vpa=6,nelement_vperp=3,Lvpa=8.0,Lvperp=4.0, bc_vpa=natural_boundary_condition, bc_vperp=natural_boundary_condition,
             ntime=50, delta_t = 1.0, ngrid=3, test_linearised_advance=false, print_diagnostics=false, print_timing=false,
             test_external_chebyshev_grid=true, continuous_integration_test=true)
         @test isapprox(expected_chebyshev.vpa_grid[:], output_pdf_and_grid.vpa_grid[:], atol=atol)

--- a/test/ImplicitCollisionsTestCI.jl
+++ b/test/ImplicitCollisionsTestCI.jl
@@ -74,14 +74,17 @@ atol = 1.0e-13
     println("Test implicit collisions demo script")
     @testset "Gauss Legendre" begin
         println("    - test Gauss Legendre")
-        output_pdf_and_grid = test_implicit_collisions(test_particle_preconditioner=true,test_numerical_conserving_terms=true,
-           vth0=0.5,vperp0=1.0,vpa0=0.1, nelement_vpa=6,nelement_vperp=3,Lvpa=8.0,Lvperp=4.0, bc_vpa="none", bc_vperp="none",
-            ntime=50, delta_t = 1.0, ngrid=3, test_linearised_advance=false, print_diagnostics=false, print_timing=false,
-            test_external_chebyshev_grid=false, continuous_integration_test=true)
-        @test isapprox(expected_gausslegendre.vpa_grid[:], output_pdf_and_grid.vpa_grid[:], atol=atol)
-        @test isapprox(expected_gausslegendre.vperp_grid[:], output_pdf_and_grid.vperp_grid[:], atol=atol)
-        for it in 1:2
-            @test isapprox(expected_gausslegendre.pdf[:,:,it], output_pdf_and_grid.pdf[:,:,it], atol=atol)
+        for test_input_array_type in (true,false)
+            output_pdf_and_grid = test_implicit_collisions(test_particle_preconditioner=true,test_numerical_conserving_terms=true,
+            vth0=0.5,vperp0=1.0,vpa0=0.1, nelement_vpa=6,nelement_vperp=3,Lvpa=8.0,Lvperp=4.0, bc_vpa="none", bc_vperp="none",
+                ntime=50, delta_t = 1.0, ngrid=3, test_linearised_advance=false, print_diagnostics=false, print_timing=false,
+                test_external_chebyshev_grid=false, continuous_integration_test=true,
+                test_input_array_type=test_input_array_type)
+            @test isapprox(expected_gausslegendre.vpa_grid[:], output_pdf_and_grid.vpa_grid[:], atol=atol)
+            @test isapprox(expected_gausslegendre.vperp_grid[:], output_pdf_and_grid.vperp_grid[:], atol=atol)
+            for it in 1:2
+                @test isapprox(expected_gausslegendre.pdf[:,:,it], output_pdf_and_grid.pdf[:,:,it], atol=atol)
+            end
         end
     end
     @testset "Gauss Chebyshev" begin

--- a/test/Interface.jl
+++ b/test/Interface.jl
@@ -48,26 +48,22 @@ ngrid = 5
 nelement_global_vperp = 2
 Lvperp = 3.0
 element_spacing_option="uniform"
-bc_vperp="none"
 
 nelement_global_vpa = 4
 Lvpa = 6.0
-bc_vpa="none"
 # create the coordinate structs
 vperp = finite_element_coordinate("vperp", scalar_coordinate_inputs(ngrid,
                             nelement_global_vperp,
                             Lvperp),
-                            element_spacing_option=element_spacing_option,
-                            bc=bc_vperp)
+                            element_spacing_option=element_spacing_option)
 vpa = finite_element_coordinate("vpa", scalar_coordinate_inputs(ngrid,
                             nelement_global_vpa,
                             Lvpa),
-                            element_spacing_option=element_spacing_option,
-                            bc=bc_vpa)
+                            element_spacing_option=element_spacing_option)
 
 
-vperpnew = finite_element_coordinate("vperp",vperp.element_data, bc=bc_vperp)
-vpanew = finite_element_coordinate("vpa",vpa.element_data, bc=bc_vpa)
+vperpnew = finite_element_coordinate("vperp",vperp.element_data)
+vpanew = finite_element_coordinate("vpa",vpa.element_data)
 
 
 @testset "coordinate creation" begin

--- a/test/calculus_tests.jl
+++ b/test/calculus_tests.jl
@@ -2,7 +2,9 @@ module CalculusTests
 
 using Test: @testset, @test
 using StableRNGs
-using FokkerPlanck.coordinates: finite_element_coordinate, first_derivative!, scalar_coordinate_inputs
+using FokkerPlanck.coordinates: finite_element_coordinate,
+                            first_derivative!,
+                            scalar_coordinate_inputs
 using FokkerPlanck.calculus: integral
 using LinearAlgebra: mul!, ldiv!
 
@@ -23,11 +25,9 @@ function runtests()
                 etol = 1.0e-14
                 element_spacing_option = "uniform"
                 L = 6.0
-                bc = "none"
                 # create the coordinate struct 'x'
                 x = finite_element_coordinate("coord", scalar_coordinate_inputs(ngrid,
                                      nelement, L),
-                                     bc=bc,
                                      element_spacing_option=element_spacing_option)
                 # create array for the function f(x) to be differentiated/integrated
                 f = Array{Float64,1}(undef, x.n)
@@ -57,16 +57,13 @@ function runtests()
         rng = StableRNG(42)
 
         @testset "GaussLegendre pseudospectral derivatives (4 argument), testing exact polynomials" verbose=false begin
-            @testset "$nelement $ngrid" for bc ∈ ("constant", "zero"),
-                    nelement ∈ (1:5), ngrid ∈ (3:17)
+            @testset "$nelement $ngrid" for nelement ∈ (1:5), ngrid ∈ (3:17)
                     
                 # define inputs needed for the test
                 L = 1.0
-                bc = "constant"
                 # create the coordinate struct 'x'
                 x = finite_element_coordinate("coord", scalar_coordinate_inputs(ngrid,
                                       nelement, L),
-                                      bc=bc,
                                       element_spacing_option="uniform")
                 # test polynomials up to order ngrid-1
                 for n ∈ 0:ngrid-1

--- a/test/fokker_planck_tests.jl
+++ b/test/fokker_planck_tests.jl
@@ -7,7 +7,9 @@ export backward_Euler_fokker_planck_self_collisions_test
 
 using LinearAlgebra: mul!, ldiv!
 using FokkerPlanck.array_allocation: allocate_float
-using FokkerPlanck.coordinates: finite_element_coordinate, scalar_coordinate_inputs
+using FokkerPlanck.coordinates: finite_element_coordinate, scalar_coordinate_inputs,
+                                finite_element_boundary_condition_type,
+                                natural_boundary_condition, zero_boundary_condition
 using FokkerPlanck.type_definitions: mk_float, mk_int
 using FokkerPlanck.velocity_moments: get_density, get_upar, get_pressure, get_ppar, get_pperp, get_qpar, get_rmom
 using FokkerPlanck.fokker_planck_calculus: direct_integration, multipole_expansion, delta_f_multipole
@@ -28,7 +30,7 @@ using FokkerPlanck.fokker_planck_calculus: advance_linearised_test_particle_coll
                                             fokkerplanck_arrays_direct_integration_struct
 
 function create_grids(ngrid,nelement_vpa,nelement_vperp;
-                      Lvpa=12.0,Lvperp=6.0,bc_vpa="zero",bc_vperp="zero")
+                      Lvpa=12.0,Lvperp=6.0,bc_vpa=zero_boundary_condition,bc_vperp=zero_boundary_condition)
 
         # create the 'input' struct containing input info needed to create a
         # coordinate
@@ -59,8 +61,8 @@ function backward_Euler_linearised_collisions_test(;
                 ngrid = 5,
                 nelement_vpa = 16,
                 nelement_vperp = 8,
-                bc_vpa="none",
-                bc_vperp="none",
+                bc_vpa=natural_boundary_condition,
+                bc_vperp=natural_boundary_condition,
                 ms = 1.0,
                 delta_t = 1.0,
                 nuss = 1.0,
@@ -172,11 +174,11 @@ function diagnose_F_Maxwellian(pdf,pdf_exact,pdf_dummy_1,pdf_dummy_2,vpa,vperp,t
     println("dens: ", dens)
     println("upar: ", upar)
     println("vth: ", vth)
-    if vpa.bc == "zero"
+    if vpa.bc == zero_boundary_condition
         println("test vpa bc: F[1, :]", pdf[1, :])
         println("test vpa bc: F[end, :]", pdf[end, :])
     end
-    if vperp.bc == "zero"
+    if vperp.bc == zero_boundary_condition
         println("test vperp bc: F[:, end]", pdf[:, end])
     end
     return nothing
@@ -202,8 +204,8 @@ function backward_Euler_fokker_planck_self_collisions_test(;
     nelement_vperp=8,
     Lvpa=10.0,
     Lvperp=5.0,
-    bc_vpa="none",
-    bc_vperp="none",
+    bc_vpa=natural_boundary_condition,
+    bc_vperp=natural_boundary_condition,
     # timestepping parameters
     ntime=100,
     delta_t=1.0,
@@ -237,13 +239,13 @@ function backward_Euler_fokker_planck_self_collisions_test(;
             end
         end
     end
-    if vpa.bc == "zero"
+    if vpa.bc == zero_boundary_condition
         @inbounds for ivperp in 1:vperp.n
             Fold[1,ivperp] = 0.0
             Fold[end,ivperp] = 0.0
         end
     end
-    if vperp.bc == "zero"
+    if vperp.bc == zero_boundary_condition
         @inbounds for ivpa in 1:vpa.n
             Fold[ivpa,end] = 0.0
         end
@@ -474,7 +476,7 @@ function runtests()
         println("Fokker Planck tests")
         @testset "backward-Euler nonlinear Fokker-Planck collisions" begin
             println("    - test backward-Euler nonlinear Fokker-Planck collisions")
-            @testset "$bc" for bc in ("none", "zero")  
+            @testset "$bc" for bc in (natural_boundary_condition, zero_boundary_condition)  
                 println("        -  bc=$bc")
                 # here test that a Maxwellian initial condition remains Maxwellian,
                 # i.e., we check the numerical Maxwellian is close to the analytical one.
@@ -1070,7 +1072,7 @@ function runtests()
         
         @testset "backward-Euler linearised test particle collisions" begin
             println("    - test backward-Euler linearised test particle collisions")
-            @testset "$bc" for bc in ("none", "zero")  
+            @testset "$bc" for bc in (natural_boundary_condition, zero_boundary_condition)  
                 println("        -  bc=$bc")
                 backward_Euler_linearised_collisions_test(bc_vpa=bc,bc_vperp=bc,
                  use_Maxwellian_Rosenbluth_coefficients_in_preconditioner=true)

--- a/test/fokker_planck_tests.jl
+++ b/test/fokker_planck_tests.jl
@@ -288,7 +288,7 @@ function backward_Euler_fokker_planck_self_collisions_test(;
     end
     for it in 1:ntime
         fokker_planck_self_collisions_backward_euler_step!(Fold, delta_t, ms, nuss, fkpl_arrays,
-            test_numerical_conserving_terms=test_numerical_conserving_terms,
+            use_conserving_corrections=test_numerical_conserving_terms,
             test_particle_preconditioner=test_particle_preconditioner,
             test_linearised_advance=test_linearised_advance,
             use_Maxwellian_Rosenbluth_coefficients_in_preconditioner=use_Maxwellian_Rosenbluth_coefficients_in_preconditioner)

--- a/test/velocity_integral_tests.jl
+++ b/test/velocity_integral_tests.jl
@@ -17,29 +17,24 @@ function runtests()
         nelement = 20 # number of elements per rank
         Lvpa = 18.0 #physical box size in reference units 
         Lvperp = 9.0 #physical box size in reference units 
-        bc = "" #not required to take a particular value, not used 
         element_spacing_option = "uniform"
         # create the coordinate structs
         vr = finite_element_coordinate("vperp1d", scalar_coordinate_inputs(1,
                                 1,
                                 1.0),
-                                element_spacing_option=element_spacing_option,
-                                bc=bc)
+                                element_spacing_option=element_spacing_option)
         vz = finite_element_coordinate("vpa1d", scalar_coordinate_inputs(ngrid,
                                 nelement,
                                 Lvpa),
-                                element_spacing_option=element_spacing_option,
-                                bc=bc)
+                                element_spacing_option=element_spacing_option)
         vperp = finite_element_coordinate("vperp", scalar_coordinate_inputs(ngrid,
                                 nelement,
                                 Lvperp),
-                                element_spacing_option=element_spacing_option,
-                                bc=bc)
+                                element_spacing_option=element_spacing_option)
         vpa = finite_element_coordinate("vpa", scalar_coordinate_inputs(ngrid,
                                 nelement,
                                 Lvpa),
-                                element_spacing_option=element_spacing_option,
-                                bc=bc)
+                                element_spacing_option=element_spacing_option)
         
         dfn = allocate_float(vpa.n,vperp.n)
         dfn1D = allocate_float(vz.n, vr.n)


### PR DESCRIPTION
Here we
 - make typing of the input pdf less restrictive
 - make an enum for specifying the pdf boundary condition, to avoid string inputs
 - make flags for conserving corrections consistent across functions.