### PR TITLE
Multi species refactor: fixed species contributions

### DIFF
--- a/src/FokkerPlanck.jl
+++ b/src/FokkerPlanck.jl
@@ -37,6 +37,8 @@ export fokker_planck_cross_species_collision_operator_Maxwellian_Fsp!
 export calculate_entropy_production
 # implicit advance
 export fokker_planck_collisions_backward_euler_step!
+# fixed background plasma inputs
+export fixed_background_plasma_input
 
 using Dates
 using LinearAlgebra: lu, ldiv!
@@ -53,7 +55,8 @@ using ..fokker_planck_calculus: fokkerplanck_weakform_arrays_struct, fokker_plac
                                 multipole_expansion, direct_integration, delta_f_multipole, boundary_data_type,
                                 conserving_corrections!, density_conserving_correction!,
                                 species_info, calculate_cross_species_rosenbluth_potential_sums!,
-                                multi_species_operator_type, single_assembly_per_species, repeat_assembly_per_species
+                                multi_species_operator_type, single_assembly_per_species, repeat_assembly_per_species,
+                                fixed_background_plasma_input
 using ..fokker_planck_test: d2Gdvpa2_Maxwellian, d2Gdvperpdvpa_Maxwellian, d2Gdvperp2_Maxwellian, dHdvpa_Maxwellian, dHdvperp_Maxwellian,
                             F_Maxwellian, dFdvpa_Maxwellian, dFdvperp_Maxwellian
 using JacobianFreeNewtonKrylov: newton_solve!
@@ -156,11 +159,13 @@ function fokker_planck_collision_operator_weak_form!(
         # species species' pair of collison operators using finite-element integrals
         # storage for summed potentials
         rosenbluth_potentials = fkpl_arrays.rosenbluth_potentials
+        fixed_background_plasma = fkpl_arrays.fixed_background_plasma
         # for each species, sum up the Rosenbluth potentials to make the appropriate
         # total Rosenbluth potential, and assemble the collision operator
         for is in 1:species.n
             calculate_cross_species_rosenbluth_potential_sums!(rosenbluth_potentials,
-                    rosenbluth_potentials_s,species,is)
+                    rosenbluth_potentials_s,species,species.zeds[is],species.mass[is],
+                    fixed_background_plasma)
             # assemble weak form and solve mass matrix problem for CCssp
             @views fokker_planck_collision_operator_solve!(
                          CCs[:,:,is], ff_in[:,:,is], rosenbluth_potentials, 1.0, 1.0, nuref,

--- a/src/FokkerPlanck.jl
+++ b/src/FokkerPlanck.jl
@@ -1,22 +1,25 @@
 """
-Module for including the Full-F Fokker-Planck Collision Operator.
+Package for computing the Full-F Fokker-Planck Collision Operator.
 
-The functions in this module are split into two groups.
+We implement the multi-species Collision operator
+using the Rosenbluth-MacDonald-Judd formulation in a divergence form.
+The Rosenbluth potentials are found using Poisson solvers
+with boundary data supplied either from multipole expansions
+or direct integration of the Rosenbluth potential definitions.
+Higher-order finite element methods are used, with a projection
+onto a weak-form using a nodal basis.
+Results are returned evaluated on collocation points.
 
-The first set of functions implement the weak-form
-Collision operator using the Rosenbluth-MacDonald-Judd
-formulation in a divergence form. The Green's functions
-for the Rosenbluth potentials are used to obtain the Rosenbluth
-potentials at the boundaries. To find the potentials
-everywhere else elliptic solves of the PDEs for the
-Rosenbluth potentials are performed with Dirichlet
-boundary conditions. These routines provide the default collision operator
-used in the code.
+An implicit backward Euler solver with time-lagged preconditioner
+is provided for testing purposes.
 
-The second set of functions are used to set up the necessary arrays to
-compute the Rosenbluth potentials everywhere in vpa, vperp
-by direct integration of the Green's functions. These functions are
-supported for the purposes of testing and debugging.
+Documentation of methods can be found in the following publication.
+
+M.R. Hardman, M. Abazorius, J. Omotani, M. Barnes, S.L. Newton, J.W.S. Cook, P.E. Farrell, F.I. Parra,
+A higher-order finite-element implementation of the nonlinear Fokker--Planck collision operator for charged particle collisions in a low density plasma,
+Computer Physics Communications, Volume 314, 2025, 109675,
+https://doi.org/10.1016/j.cpc.2025.109675
+
 """
 module FokkerPlanck
 

--- a/src/FokkerPlanck.jl
+++ b/src/FokkerPlanck.jl
@@ -33,7 +33,7 @@ include("fokker_planck_nonlinear_solvers.jl")
 include("fokker_planck_calculus.jl")
 
 export fokker_planck_collision_operator_weak_form!
-export fokker_planck_cross_species_collision_operator_Maxwellian_Fsp!
+# entropy diagnostic
 export calculate_entropy_production
 # implicit advance
 export fokker_planck_collisions_backward_euler_step!
@@ -225,7 +225,7 @@ function fokker_planck_collision_operator_weak_form!(
 end
 
 """
-Cross-species collisions due to fixed background plasma
+Cross-species collisions due to fixed background plasma.
 """
 function fokker_planck_cross_species_collision_operator!(
                         CC::AbstractArray{mk_float,2},
@@ -248,107 +248,6 @@ function fokker_planck_cross_species_collision_operator!(
         # make ad-hoc conserving corrections
         density_conserving_correction!(CC,ff_in,vpa,vperp)
     end
-    return nothing
-end
-function fokker_planck_cross_species_collision_operator_Maxwellian_Fsp!(
-                        CC::AbstractArray{mk_float,2},
-                        ffs_in::AbstractArray{mk_float,2},
-                        nuref::mk_float, ms::mk_float, Zs::mk_float,
-                        msp::Array{mk_float,1}, Zsp::Array{mk_float,1},
-                        densp::Array{mk_float,1}, uparsp::Array{mk_float,1},
-                        vthsp::Array{mk_float,1},
-                        fkpl_arrays::fokkerplanck_weakform_arrays_struct;
-                        use_conserving_corrections=true::Bool)
-
-    fokker_planck_collision_operator_weak_form_Maxwellian_Fsp!(
-        CC,ffs_in,
-        nuref,ms,Zs,msp,Zsp,densp,uparsp,vthsp,
-        fkpl_arrays)
-    if use_conserving_corrections
-        vpa = fkpl_arrays.vpa
-        vperp = fkpl_arrays.vperp
-        # enforce the boundary conditions on CC before it is used for timestepping
-        enforce_vpavperp_BCs!(CC,vpa,vperp)
-        # make ad-hoc conserving corrections
-        density_conserving_correction!(CC,ffs_in,vpa,vperp)
-    end
-    return nothing
-end
-
-"""
-Function for computing the collision operator
-```math
-\\sum_{s^\\prime} C[F_{s},F_{s^\\prime}]
-```
-when \$F_{s^\\prime}\$
-is an analytically specified Maxwellian distribution and
-the corresponding Rosenbluth potentials
-are specified using analytical results.
-"""
-function fokker_planck_collision_operator_weak_form_Maxwellian_Fsp!(CC::AbstractArray{mk_float,2},
-                         ffs_in::AbstractArray{mk_float,2},
-                         nuref::mk_float, ms::mk_float, Zs::mk_float,
-                         msp::Array{mk_float,1}, Zsp::Array{mk_float,1},
-                         densp::Array{mk_float,1}, uparsp::Array{mk_float,1},
-                         vthsp::Array{mk_float,1},
-                         fkpl_arrays::fokkerplanck_weakform_arrays_struct)
-    vpa = fkpl_arrays.vpa
-    vperp = fkpl_arrays.vperp
-    @boundscheck vpa.n == size(ffs_in,1) || throw(BoundsError(ffs_in))
-    @boundscheck vperp.n == size(ffs_in,2) || throw(BoundsError(ffs_in))
-
-    # extract the necessary precalculated and buffer arrays from fokkerplanck_arrays
-    rhsvpavperp = fkpl_arrays.fprp_solver_data.matrix_operators.rhsvpavperp
-    lu_obj_MM = fkpl_arrays.fprp_solver_data.matrix_operators.lu_obj_MM
-    YY_arrays = fkpl_arrays.YY_arrays
-    rosenbluth_potentials = fkpl_arrays.rosenbluth_potentials
-    dHdvpa = rosenbluth_potentials.dHdvpa
-    dHdvperp = rosenbluth_potentials.dHdvperp
-    d2Gdvperp2 = rosenbluth_potentials.d2Gdvperp2
-    d2Gdvpa2 = rosenbluth_potentials.d2Gdvpa2
-    d2Gdvperpdvpa = rosenbluth_potentials.d2Gdvperpdvpa
-
-    # number of primed species
-    nsp = size(msp,1)
-
-    # first set dummy arrays for coefficients to zero
-    @inbounds begin
-        for ivperp in 1:vperp.n
-            for ivpa in 1:vpa.n
-                d2Gdvpa2[ivpa,ivperp] = 0.0
-                d2Gdvperp2[ivpa,ivperp] = 0.0
-                d2Gdvperpdvpa[ivpa,ivperp] = 0.0
-                dHdvpa[ivpa,ivperp] = 0.0
-                dHdvperp[ivpa,ivperp] = 0.0
-            end
-        end
-    end
-    # sum the contributions from the potentials, including order unity factors that differ between species
-    # making use of the Linearity of the operator in Fsp
-    # note that here we absorb ms/msp and Zsp^2 into the definition of the potentials, and we pass
-    # ms = msp = 1 to the collision operator assembly routine so that we can use a single array to include
-    # the contribution to the summed Rosenbluth potential from all the species
-    for isp in 1:nsp
-        dens = densp[isp]
-        upar = uparsp[isp]
-        vth = vthsp[isp]
-        ZZ = (Zsp[isp]*Zs/ms)^2 # factor from gamma_ss'/m_s^2 = Z_s^2 Z_s'^2 / m_s^2
-        @inbounds begin
-            for ivperp in 1:vperp.n
-                for ivpa in 1:vpa.n
-                    d2Gdvpa2[ivpa,ivperp] += ZZ*d2Gdvpa2_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
-                    d2Gdvperp2[ivpa,ivperp] += ZZ*d2Gdvperp2_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
-                    d2Gdvperpdvpa[ivpa,ivperp] += ZZ*d2Gdvperpdvpa_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
-                    dHdvpa[ivpa,ivperp] += ZZ*(ms/msp[isp])*dHdvpa_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
-                    dHdvperp[ivpa,ivperp] += ZZ*(ms/msp[isp])*dHdvperp_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
-                end
-            end
-        end
-    end
-    # assemble weak form and solve mass matrix problem for Cs
-    @views fokker_planck_collision_operator_solve!(
-                         CC, ffs_in, rosenbluth_potentials, 1.0, 1.0, nuref,
-                         rhsvpavperp, lu_obj_MM, YY_arrays, vpa, vperp)
     return nothing
 end
 

--- a/src/FokkerPlanck.jl
+++ b/src/FokkerPlanck.jl
@@ -205,6 +205,16 @@ function fokker_planck_collision_operator_weak_form!(
                 # sum up the collision operator contributions
                 @. CCs[:,:,is] += Cssp
             end
+            # cross-species contributions from fixed background
+            @views fokker_planck_cross_species_collision_operator!(
+                        Cssp,
+                        ff_in[:,:,is],
+                        nuref, mass[is], zeds[is],
+                        fkpl_arrays.rosenbluth_potentials,
+                        fkpl_arrays.fixed_background_plasma,
+                        rhsvpavperp, lu_obj_MM, YY_arrays, vpa, vperp;
+                        use_conserving_corrections=use_conserving_corrections)
+            @views CCs[:,:,is] += Cssp
         end
     end
     if use_conserving_corrections
@@ -214,8 +224,32 @@ function fokker_planck_collision_operator_weak_form!(
     return nothing
 end
 
-
-
+"""
+Cross-species collisions due to fixed background plasma
+"""
+function fokker_planck_cross_species_collision_operator!(
+                        CC::AbstractArray{mk_float,2},
+                        ff_in::AbstractArray{mk_float,2},
+                        nuref::mk_float, ms::mk_float, Zs::mk_float,
+                        rosenbluth_potentials,
+                        fixed_background_plasma,
+                        rhsvpavperp, lu_obj_MM, YY_arrays, vpa, vperp;
+                        use_conserving_corrections=true::Bool)
+    # calculate the Rosenbluth potentials due to the background plasma
+    calculate_cross_species_rosenbluth_potential_sums!(rosenbluth_potentials,
+                    Zs,ms,fixed_background_plasma)
+    # assemble weak form, solve mass matrix for CC at collocation points
+    fokker_planck_collision_operator_solve!(
+                    CC, ff_in, rosenbluth_potentials, 1.0, 1.0, nuref,
+                    rhsvpavperp, lu_obj_MM, YY_arrays, vpa, vperp)
+    if use_conserving_corrections
+        # enforce the boundary conditions on CC before it is used for timestepping
+        enforce_vpavperp_BCs!(CC,vpa,vperp)
+        # make ad-hoc conserving corrections
+        density_conserving_correction!(CC,ff_in,vpa,vperp)
+    end
+    return nothing
+end
 function fokker_planck_cross_species_collision_operator_Maxwellian_Fsp!(
                         CC::AbstractArray{mk_float,2},
                         ffs_in::AbstractArray{mk_float,2},

--- a/src/fokker_planck_calculus.jl
+++ b/src/fokker_planck_calculus.jl
@@ -3462,8 +3462,18 @@ end
 """
 function calculate_cross_species_rosenbluth_potential_sums!(
                 rosenbluth_potentials::rosenbluth_potential_data,
-                rosenbluth_potentials_s::Vector{rosenbluth_potential_data},
-                species,Zs::mk_float,ms::mk_float,
+                Zs::mk_float,ms::mk_float,
+                fixed_background_plasma::Union{Nothing,fixed_background_plasma_info})
+    calculate_cross_species_rosenbluth_potential_sums!(
+                rosenbluth_potentials,
+                nothing, nothing,Zs::mk_float,ms::mk_float,
+                fixed_background_plasma)
+    return nothing
+end
+function calculate_cross_species_rosenbluth_potential_sums!(
+                rosenbluth_potentials::rosenbluth_potential_data,
+                rosenbluth_potentials_s::Union{Nothing,Vector{rosenbluth_potential_data}},
+                species::Union{Nothing,species_info},Zs::mk_float,ms::mk_float,
                 fixed_background_plasma::Union{Nothing,fixed_background_plasma_info})
     # zero Rosenbluth potentials before summation
     dHdvpa = rosenbluth_potentials.dHdvpa
@@ -3506,8 +3516,16 @@ function sum_cross_species_rosenbluth_potentials!(
 end
 function sum_cross_species_rosenbluth_potentials!(
                 rosenbluth_potentials::rosenbluth_potential_data,
+                rosenbluth_potentials_s::Nothing,
+                species::Nothing,
+                Zs::mk_float,ms::mk_float)
+    # do nothing
+    return nothing
+end
+function sum_cross_species_rosenbluth_potentials!(
+                rosenbluth_potentials::rosenbluth_potential_data,
                 rosenbluth_potentials_s::Vector{rosenbluth_potential_data},
-                species,Zs::mk_float,ms::mk_float)
+                species::species_info,Zs::mk_float,ms::mk_float)
     dHdvpa = rosenbluth_potentials.dHdvpa
     dHdvperp = rosenbluth_potentials.dHdvperp
     d2Gdvperp2 = rosenbluth_potentials.d2Gdvperp2

--- a/src/fokker_planck_calculus.jl
+++ b/src/fokker_planck_calculus.jl
@@ -28,6 +28,7 @@ export matrix_inverse
 export multi_species_operator_type, single_assembly_per_species, repeat_assembly_per_species
 export calculate_collision_moments!
 export fokker_planck_collision_operator_solve!
+export fixed_background_plasma_input
 
 using ..type_definitions: mk_float, mk_int
 using ..array_allocation: allocate_float
@@ -760,7 +761,7 @@ struct species_info
     """
     Internal constructor for `species_info`.
     """
-    function species_info(mass,zeds)
+    function species_info(mass::Vector{mk_float},zeds::Vector{mk_float})
         # number of species
         nspecies = length(zeds)
         # check inputs are consistent
@@ -775,6 +776,91 @@ struct species_info
     end
 end
 
+
+"""
+"""
+struct pdf_moments
+    density::Vector{mk_float}
+    upar::Vector{mk_float}
+    vth::Vector{mk_float}
+end
+"""
+"""
+struct fixed_background_plasma_input
+    species::species_info
+    pdf::Union{pdf_moments,AbstractArray{mk_float,3}}
+    function fixed_background_plasma_input(mass::Vector{mk_float},
+                                    zeds::Vector{mk_float},
+                                    pdf::Union{pdf_moments,AbstractArray{mk_float,3}})
+        species = species_info(mass,zeds)
+        return new(species,pdf)
+    end
+    function fixed_background_plasma_input(mass::Vector{mk_float},
+                                    zeds::Vector{mk_float},
+                                    density::Vector{mk_float},
+                                    upar::Vector{mk_float},
+                                    vth::Vector{mk_float})
+        species = species_info(mass,zeds)
+        pdf = pdf_moments(density,upar,vth)
+        return new(species,pdf)
+    end
+end
+"""
+"""
+struct fixed_background_plasma_info
+    species::species_info
+    rosenbluth_potentials_s::Vector{rosenbluth_potential_data}
+    # internal constructor for Maxwellian background plasma species
+    function fixed_background_plasma_info(fixed_background_plasma_in::fixed_background_plasma_input,
+                                    vpa::finite_element_coordinate,
+                                    vperp::finite_element_coordinate,
+                                    fprp_solver_data::fokkerplanck_rosenbluth_potential_solver_data)
+        species = fixed_background_plasma_in.species
+        pdf = fixed_background_plasma_in.pdf
+        return fixed_background_plasma_info(species, pdf, vpa, vperp, fprp_solver_data)
+    end
+    function fixed_background_plasma_info(species::species_info,
+                                    pdf::pdf_moments,
+                                    vpa::finite_element_coordinate,
+                                    vperp::finite_element_coordinate,
+                                    # unused input kept to permit the same interface
+                                    fprp_solver_data::fokkerplanck_rosenbluth_potential_solver_data)
+        density = pdf.density
+        upar = pdf.upar
+        vth = pdf.vth
+        @boundscheck species.n == length(density) || throw(BoundsError(density))
+        @boundscheck species.n == length(upar) || throw(BoundsError(upar))
+        @boundscheck species.n == length(vth) || throw(BoundsError(vth))
+        rosenbluth_potentials_s = Vector{rosenbluth_potential_data}(undef,species.n)
+        for is in 1:species.n
+            rosenbluth_potentials_s[is] = rosenbluth_potential_data(vpa,vperp)
+        end
+        for is in 1:species.n
+            calculate_rosenbluth_potentials_via_analytical_Maxwellian!(
+                rosenbluth_potentials_s[is],density[is],upar[is],vth[is],vpa,vperp)
+        end
+        return new(species, rosenbluth_potentials_s)
+    end
+    # internal constructor for non-Maxwellian background plasma species
+    function fixed_background_plasma_info(species::species_info,
+                                    pdf::AbstractArray{mk_float,3},
+                                    vpa::finite_element_coordinate,
+                                    vperp::finite_element_coordinate,
+                                    fprp_solver_data::fokkerplanck_rosenbluth_potential_solver_data)
+        @boundscheck (species.n == size(pdf,3) && vperp.n == size(pdf,2) && vpa.n == size(pdf,1)) || throw(BoundsError(pdf))
+        rosenbluth_potentials_s = Vector{rosenbluth_potential_data}(undef,species.n)
+        for is in 1:species.n
+            rosenbluth_potentials_s[is] = rosenbluth_potential_data(vpa,vperp)
+        end
+        for is in 1:species.n
+            @views calculate_rosenbluth_potentials_via_elliptic_solve!(rosenbluth_potentials_s[is],pdf[:,:,is],
+             vpa,vperp,fprp_solver_data,species.mass[is],
+             algebraic_solve_for_d2Gdvperp2=false,calculate_GG=false,
+             calculate_dGdvperp=false)
+        end
+        return new(species, rosenbluth_potentials_s)
+    end
+end
 """
 Struct of dummy arrays and precalculated coefficients
 for the finite-element weak-form Fokker-Planck collision operator.
@@ -813,6 +899,8 @@ struct fokkerplanck_weakform_arrays_struct
     delta_pdf::Array{mk_float,3}
     # option to control which numerical error corrections method to use
     multi_species_operator_option::multi_species_operator_type
+    # data needed to include contributions from unevolved plasma species
+    fixed_background_plasma::Union{fixed_background_plasma_info,Nothing}
     """
     Function that initialises the arrays needed for Fokker Planck collisions
     using numerical integration to compute the Rosenbluth potentials only
@@ -824,7 +912,8 @@ struct fokkerplanck_weakform_arrays_struct
                                                 species::species_info,
                                                 boundary_data_option::boundary_data_type;
                                                 multi_species_operator_option=single_assembly_per_species::multi_species_operator_type,
-                                                print_to_screen=true::Bool)
+                                                print_to_screen=true::Bool,
+                                                fixed_background_plasma_in=nothing::Union{fixed_background_plasma_input,Nothing})
         YY_arrays = YY_collision_operator_arrays(vpa,vperp)
         fprp_solver_data = fokkerplanck_rosenbluth_potential_solver_data(vpa,vperp,
                                 YY_arrays,boundary_data_option,print_to_screen=print_to_screen)
@@ -850,12 +939,19 @@ struct fokkerplanck_weakform_arrays_struct
         delta_E = allocate_float(nspecies)
         correction_coeffs_z = allocate_float(3,nspecies,nspecies)
         delta_pdf = allocate_float(nvpa,nvperp,nspecies)
+        # Rosenbluth potentials and species info for unevolved species
+        if typeof(fixed_background_plasma_in) == fixed_background_plasma_input
+            fixed_background_plasma = fixed_background_plasma_info(fixed_background_plasma_in,
+                                            vpa,vperp,fprp_solver_data)
+        else
+            fixed_background_plasma = nothing
+        end
         return new(vpa, vperp, species, fprp_solver_data, YY_arrays,
                     rosenbluth_potentials_s, rosenbluth_potentials,
                     delta_n_sp_s, delta_m_sp_s, delta_p_sp_s,
                     density, upar, pressure, ppar, qpar, rmom,
                     delta_n, delta_P, delta_E, correction_coeffs_z, delta_pdf,
-                    multi_species_operator_option)
+                    multi_species_operator_option, fixed_background_plasma)
     end
 end
 
@@ -906,8 +1002,8 @@ struct fokker_plack_backward_euler_data
         nl_solver_atol=1.0e-10::mk_float,
         nl_solver_rtol=0.0::mk_float,
         nl_solver_nonlinear_max_iterations=20::mk_int,
-        print_to_screen=true::Bool)
-
+        print_to_screen=true::Bool,
+        fixed_background_plasma_in=nothing::Union{fixed_background_plasma_input,Nothing})
         # create the coordinate structs from the input data
         vperp = finite_element_coordinate("vperp", inputs_vperp,
                                     bc=bc_vperp)
@@ -918,7 +1014,7 @@ struct fokker_plack_backward_euler_data
         return fokker_plack_backward_euler_data(vpa,vperp,species,
                     boundary_data_option,multi_species_operator_option,
                     nl_solver_atol,nl_solver_rtol,nl_solver_nonlinear_max_iterations,
-                    print_to_screen)
+                    print_to_screen,fixed_background_plasma_in)
     end
     # constructor without optional arguments
     function fokker_plack_backward_euler_data(vpa::finite_element_coordinate,
@@ -929,7 +1025,8 @@ struct fokker_plack_backward_euler_data
                                     nl_solver_atol::mk_float,
                                     nl_solver_rtol::mk_float,
                                     nl_solver_nonlinear_max_iterations::mk_int,
-                                    print_to_screen::Bool)
+                                    print_to_screen::Bool,
+                                    fixed_background_plasma_in::Union{fixed_background_plasma_input,Nothing})
         nvpa, nvperp, nspecies = vpa.n, vperp.n, species.n
         # collision operator arrays for intermediate results
         CCs = allocate_float(nvpa,nvperp,nspecies)
@@ -954,7 +1051,8 @@ struct fokker_plack_backward_euler_data
         fp_operator = fokkerplanck_weakform_arrays_struct(vpa,vperp,species,
                                                 boundary_data_option;
                                                 multi_species_operator_option=multi_species_operator_option,
-                                                print_to_screen=print_to_screen)
+                                                print_to_screen=print_to_screen,
+                                                fixed_background_plasma_in=fixed_background_plasma_in)
         return new(CCs,
             CC2D_sparse,CC2D_sparse_constructor,lu_obj_CC2D,
             lu_objs_CC2D,
@@ -2637,6 +2735,9 @@ function calculate_test_particle_preconditioner!(pdf::AbstractArray{mk_float,3},
     # dummy arrays for Rosenbluth potentials
     rosenbluth_potentials_s = fp_operator.rosenbluth_potentials_s
     rosenbluth_potentials = fp_operator.rosenbluth_potentials
+    # information about fixed background plasma
+    fixed_background_plasma = fp_operator.fixed_background_plasma
+    # compute potentials due to evolved species
     if use_Maxwellian_Rosenbluth_coefficients
         for is in 1:species.n
             @views calculate_rosenbluth_potentials_via_analytical_Maxwellian!(
@@ -2656,7 +2757,8 @@ function calculate_test_particle_preconditioner!(pdf::AbstractArray{mk_float,3},
         for is in 1:species.n
             calculate_cross_species_rosenbluth_potential_sums!(
                     rosenbluth_potentials,rosenbluth_potentials_s,
-                    species,is)
+                    species,species.zeds[is],species.mass[is],
+                    fixed_background_plasma)
             assemble_collision_operator_preconditioner_rhs!(CC2D_sparse_constructor,
                 rosenbluth_potentials,delta_t,nuref,fp_operator)
             # should improve on this step to avoid recreating the sparse array if possible.
@@ -3245,6 +3347,18 @@ function calculate_rosenbluth_potentials_via_analytical_Maxwellian!(
     rosenbluth_potentials::rosenbluth_potential_data,
     ffsp_in::AbstractArray{mk_float,2},vpa::finite_element_coordinate,
     vperp::finite_element_coordinate,mass::mk_float)
+    dens = get_density(ffsp_in, vpa, vperp)
+    upar = get_upar(ffsp_in, vpa, vperp, dens)
+    pressure = get_pressure(ffsp_in, vpa, vperp, upar, mass)
+    vth = sqrt(2.0*pressure/(dens*mass))
+    calculate_rosenbluth_potentials_via_analytical_Maxwellian!(
+        rosenbluth_potentials,dens,upar,vth,vpa,vperp)
+    return nothing
+end
+function calculate_rosenbluth_potentials_via_analytical_Maxwellian!(
+    rosenbluth_potentials::rosenbluth_potential_data,
+    dens::mk_float,upar::mk_float,vth::mk_float,
+    vpa::finite_element_coordinate,vperp::finite_element_coordinate)
     GG = rosenbluth_potentials.GG
     HH = rosenbluth_potentials.HH
     dHdvpa = rosenbluth_potentials.dHdvpa
@@ -3253,10 +3367,6 @@ function calculate_rosenbluth_potentials_via_analytical_Maxwellian!(
     d2Gdvperp2 = rosenbluth_potentials.d2Gdvperp2
     d2Gdvpa2 = rosenbluth_potentials.d2Gdvpa2
     d2Gdvperpdvpa = rosenbluth_potentials.d2Gdvperpdvpa
-    dens = get_density(ffsp_in, vpa, vperp)
-    upar = get_upar(ffsp_in, vpa, vperp, dens)
-    pressure = get_pressure(ffsp_in, vpa, vperp, upar, mass)
-    vth = sqrt(2.0*pressure/(dens*mass))
     @inbounds begin
         for ivperp in 1:vperp.n
             for ivpa in 1:vpa.n
@@ -3353,7 +3463,51 @@ end
 function calculate_cross_species_rosenbluth_potential_sums!(
                 rosenbluth_potentials::rosenbluth_potential_data,
                 rosenbluth_potentials_s::Vector{rosenbluth_potential_data},
-                species,is::mk_int)
+                species,Zs::mk_float,ms::mk_float,
+                fixed_background_plasma::Union{Nothing,fixed_background_plasma_info})
+    # zero Rosenbluth potentials before summation
+    dHdvpa = rosenbluth_potentials.dHdvpa
+    dHdvperp = rosenbluth_potentials.dHdvperp
+    d2Gdvperp2 = rosenbluth_potentials.d2Gdvperp2
+    d2Gdvpa2 = rosenbluth_potentials.d2Gdvpa2
+    d2Gdvperpdvpa = rosenbluth_potentials.d2Gdvperpdvpa
+    d2Gdvpa2 .= 0.0
+    d2Gdvperpdvpa .= 0.0
+    d2Gdvperp2 .= 0.0
+    dHdvpa .= 0.0
+    dHdvperp .= 0.0
+    # sum potentials from the evolved species
+    sum_cross_species_rosenbluth_potentials!(
+                rosenbluth_potentials,
+                rosenbluth_potentials_s,
+                species,Zs,ms)
+    # sum potentials from the fixed (unevolved) species
+    sum_cross_species_rosenbluth_potentials!(
+                rosenbluth_potentials,
+                fixed_background_plasma,Zs,ms)
+    return nothing
+end
+function sum_cross_species_rosenbluth_potentials!(
+                rosenbluth_potentials::rosenbluth_potential_data,
+                fixed_background_plasma::fixed_background_plasma_info,
+                Zs::mk_float,ms::mk_float)
+    sum_cross_species_rosenbluth_potentials!(
+                rosenbluth_potentials,
+                fixed_background_plasma.rosenbluth_potentials_s,
+                fixed_background_plasma.species,Zs,ms)
+    return nothing
+end
+function sum_cross_species_rosenbluth_potentials!(
+                rosenbluth_potentials::rosenbluth_potential_data,
+                fixed_background_plasma::Nothing,
+                Zs::mk_float,ms::mk_float)
+    # do nothing
+    return nothing
+end
+function sum_cross_species_rosenbluth_potentials!(
+                rosenbluth_potentials::rosenbluth_potential_data,
+                rosenbluth_potentials_s::Vector{rosenbluth_potential_data},
+                species,Zs::mk_float,ms::mk_float)
     dHdvpa = rosenbluth_potentials.dHdvpa
     dHdvperp = rosenbluth_potentials.dHdvperp
     d2Gdvperp2 = rosenbluth_potentials.d2Gdvperp2
@@ -3361,18 +3515,15 @@ function calculate_cross_species_rosenbluth_potential_sums!(
     d2Gdvperpdvpa = rosenbluth_potentials.d2Gdvperpdvpa
     mass = species.mass
     zeds = species.zeds
-    d2Gdvpa2 .= 0.0
-    d2Gdvperpdvpa .= 0.0
-    d2Gdvperp2 .= 0.0
-    dHdvpa .= 0.0
-    dHdvperp .= 0.0
     for isp in 1:species.n
         # struct for Rosenbluth potentials for species s'
         rp = rosenbluth_potentials_s[isp]
+        Zsp = zeds[isp]
+        msp = mass[isp]
         # add the contribution from species s' to the total
         # note that Coulomb logarithm factors are missing
-        G_factor = (zeds[is]*zeds[isp]/mass[is])^2
-        H_factor = ((zeds[is]*zeds[isp])^2)/(mass[is]*mass[isp])
+        G_factor = (Zs*Zsp/ms)^2
+        H_factor = ((Zs*Zsp)^2)/(ms*msp)
         @. d2Gdvpa2 += rp.d2Gdvpa2*G_factor
         @. d2Gdvperpdvpa += rp.d2Gdvperpdvpa*G_factor
         @. d2Gdvperp2 += rp.d2Gdvperp2*G_factor

--- a/test/fokker_planck_tests.jl
+++ b/test/fokker_planck_tests.jl
@@ -16,7 +16,7 @@ using FokkerPlanck.fokker_planck_calculus: direct_integration, multipole_expansi
                                             repeat_assembly_per_species, single_assembly_per_species
 
 using FokkerPlanck: fokker_plack_backward_euler_data, fokker_planck_collision_operator_weak_form!
-using FokkerPlanck: conserving_corrections!, species_info
+using FokkerPlanck: conserving_corrections!, species_info, fixed_background_plasma_input
 using FokkerPlanck: fokker_planck_cross_species_collision_operator_Maxwellian_Fsp!
 using FokkerPlanck: fokker_planck_collisions_backward_euler_step!, calculate_entropy_production
 using FokkerPlanck.fokker_planck_test: print_test_data, fkpl_error_data, allocate_error_data #, plot_test_data
@@ -93,7 +93,7 @@ function backward_Euler_linearised_collisions_test(;
                                                                 bc_vperp=bc_vperp,bc_vpa=bc_vpa)
     species = species_info([ms],[1.0])
     fkpl_arrays = fokker_plack_backward_euler_data(vpa,vperp,species,boundary_data_option,repeat_assembly_per_species,
-                        0.0, 0.0, 0, print_to_screen)
+                        0.0, 0.0, 0, print_to_screen, nothing)
     dummy_array = allocate_float(vpa.n,vperp.n)
     FMaxwell = allocate_float(vpa.n,vperp.n)
     FMaxwell_err = allocate_float(vpa.n,vperp.n)
@@ -234,7 +234,7 @@ function backward_Euler_fokker_planck_self_collisions_test(;
     nl_solver_nonlinear_max_iterations=20
     fkpl_arrays = fokker_plack_backward_euler_data(vpa,vperp,species,boundary_data_option,multi_species_operator_option,
                         nl_solver_atol,nl_solver_rtol,nl_solver_nonlinear_max_iterations,
-                        print_to_screen)
+                        print_to_screen,nothing)
 
     # initial condition
     Fold = allocate_float(vpa.n,vperp.n,species.n)
@@ -670,6 +670,119 @@ function multi_species_fokker_planck_collisions_test(; ngrid=17, nelement_vpa=8,
     end
     return nothing
 end
+
+function slowing_down_fokker_planck_collisions_test(;
+    ngrid = 9,
+    nelement_vpa = 16,
+    nelement_vperp = 8,
+    pdf_input=false,
+    print_to_screen=false)
+    vpa, vperp = create_grids(ngrid,nelement_vpa,nelement_vperp,
+                                Lvpa=12.0,Lvperp=6.0,bc_vpa=natural_boundary_condition,
+                                bc_vperp=natural_boundary_condition)
+    boundary_data_option=multipole_expansion
+    species = species_info([1.0], # mass of evolved species
+                            [2.0]) # Z of evolved species
+    nuref = 1.0/16.0 # reference collision frequency
+    # parameters of fixed background species
+    msp = [1.0,0.2]#[0.25, 0.25/1836.0]
+    Zsp = [1.0,1.0]#[0.5, 0.5]
+    denssp = [1.0,1.0]#[1.0, 1.0]
+    uparsp = [0.0,0.0]#[0.0, 0.0]
+    vthsp = [sqrt(0.5/msp[1]), sqrt(0.5/msp[2])]#[sqrt(0.01/msp[1]), sqrt(0.01/msp[2])]
+    if pdf_input
+        nsprime = length(msp)
+        Fsp_M = allocate_float(vpa.n,vperp.n,nsprime)
+        for isp in 1:nsprime
+            for ivperp in 1:vperp.n
+                for ivpa in 1:vpa.n
+                    Fsp_M[ivpa,ivperp,isp] = F_Maxwellian(denssp[isp],uparsp[isp],vthsp[isp],vpa,vperp,ivpa,ivperp)
+                end
+            end
+        end
+        fixed_background_plasma_in = fixed_background_plasma_input(msp,Zsp,Fsp_M)
+    else
+        fixed_background_plasma_in = fixed_background_plasma_input(msp,Zsp,denssp,uparsp,vthsp)
+    end
+    fkpl_arrays = fokkerplanck_weakform_arrays_struct(vpa,vperp,species,boundary_data_option,
+                            print_to_screen=print_to_screen,
+                            fixed_background_plasma_in=fixed_background_plasma_in)
+
+    @testset "test_numerical_conserving_terms=$test_numerical_conserving_terms pdf_input=$(pdf_input)" for test_numerical_conserving_terms in (true,false)
+        println("        - test_numerical_conserving_terms=$test_numerical_conserving_terms pdf_input=$(pdf_input)")
+        dummy_array = allocate_float(vpa.n,vperp.n)
+        Fs_M = allocate_float(vpa.n,vperp.n,species.n)
+        C_M_num = allocate_float(vpa.n,vperp.n,species.n)
+        C_M_exact = allocate_float(vpa.n,vperp.n,species.n)
+        C_M_err = allocate_float(vpa.n,vperp.n)
+
+        # pick a set of parameters that represent slowing down
+        # on slow ions and faster electrons, but which are close
+        # enough to 1 for errors comparable to the self-collision operator
+        # increasing or reducing vth, mass increases the errors
+        dens, upar, vth = [1.0], [1.0], [1.0]
+        nsprime = size(msp,1)
+
+        for is in 1:species.n
+            for ivperp in 1:vperp.n
+                for ivpa in 1:vpa.n
+                    Fs_M[ivpa,ivperp,is] = F_Maxwellian(dens[is],upar[is],vth[is],vpa,vperp,ivpa,ivperp)
+                    C_M_exact[ivpa,ivperp,is] = 0.0
+                end
+            end
+        end
+        for is in 1:species.n
+            ms = species.mass[is]
+            Zs = species.zeds[is]
+            # sum up contributions from evolved species
+            for isp in 1:species.n
+                for ivperp in 1:vperp.n
+                    for ivpa in 1:vpa.n
+                            C_M_exact[ivpa,ivperp,is] += Cssp_Maxwellian_inputs(dens[is],upar[is],vth[is],species.mass[is],species.zeds[is],
+                                                                        dens[isp],upar[isp],vth[isp],species.mass[isp],species.zeds[isp],
+                                                                        nuref,vpa,vperp,ivpa,ivperp)
+                    end
+                end
+            end
+            # sum up contributions to cross-collision operator from fixed background
+            for isp in 1:nsprime
+                for ivperp in 1:vperp.n
+                    for ivpa in 1:vpa.n
+                            C_M_exact[ivpa,ivperp,is] += Cssp_Maxwellian_inputs(dens[is],upar[is],vth[is],species.mass[is],species.zeds[is],
+                                                                        denssp[isp],uparsp[isp],vthsp[isp],msp[isp],Zsp[isp],
+                                                                        nuref,vpa,vperp,ivpa,ivperp)
+                    end
+                end
+            end
+        end
+        fokker_planck_collision_operator_weak_form!(
+                    C_M_num,Fs_M,nuref,fkpl_arrays;
+                    use_conserving_corrections=test_numerical_conserving_terms)
+        for is in 1:species.n
+            @views C_M_max, C_M_L2 = print_test_data(C_M_exact[:,:,is],C_M_num[:,:,is],C_M_err,"C_M",vpa,vperp,dummy_array,print_to_screen=print_to_screen)
+            atol_max = 5.0e-6
+            atol_L2 = 5.0e-8
+            @test C_M_max < atol_max
+            @test C_M_L2 < atol_L2
+            if !test_numerical_conserving_terms
+                @views delta_n = get_density(C_M_num[:,:,is], vpa, vperp)
+                rtol, atol = 0.0, 1.0e-12
+                @test isapprox(delta_n, rtol ; atol=atol)
+                if print_to_screen
+                    println("delta_n: ", delta_n)
+                end
+            elseif test_numerical_conserving_terms
+                @views delta_n = get_density(C_M_num[:,:,is], vpa, vperp)
+                rtol, atol = 0.0, 3.0e-14
+                @test isapprox(delta_n, rtol ; atol=atol)
+                if print_to_screen
+                    println("delta_n: ", delta_n)
+                end
+            end
+        end
+    end
+    return nothing
+end
 function runtests()
     print_to_screen = false
     @testset "Fokker Planck tests" begin
@@ -1086,83 +1199,8 @@ function runtests()
 
         @testset "weak-form (slowing-down) collision operator calculation" begin
             println("    - test weak-form (slowing-down) collision operator calculation")
-            ngrid = 5
-            nelement_vpa = 16
-            nelement_vperp = 8
-            vpa, vperp = create_grids(ngrid,nelement_vpa,nelement_vperp,
-                                                Lvpa=12.0,Lvperp=6.0)
-            boundary_data_option=multipole_expansion
-            species = species_info([1.0],[1.0])
-            fkpl_arrays = fokkerplanck_weakform_arrays_struct(vpa,vperp,species,boundary_data_option,
-                                    print_to_screen=print_to_screen)
-
-            @testset "slowing_down_test=true test_numerical_conserving_terms=$test_numerical_conserving_terms" for test_numerical_conserving_terms in (true,false)
-
-                dummy_array = allocate_float(vpa.n,vperp.n)
-                Fs_M = allocate_float(vpa.n,vperp.n)
-                F_M = allocate_float(vpa.n,vperp.n)
-                C_M_num = allocate_float(vpa.n,vperp.n)
-                C_M_exact = allocate_float(vpa.n,vperp.n)
-                C_M_err = allocate_float(vpa.n,vperp.n)
-
-                # pick a set of parameters that represent slowing down
-                # on slow ions and faster electrons, but which are close
-                # enough to 1 for errors comparable to the self-collision operator
-                # increasing or reducing vth, mass increases the errors
-                dens, upar, vth = 1.0, 1.0, 1.0
-                mref = 1.0 # mass of reference species, here the evolved species
-                Zref = 2.0 # Z of reference species
-                msp = [1.0,0.2]#[0.25, 0.25/1836.0]
-                Zsp = [1.0,1.0]#[0.5, 0.5]
-                denssp = [1.0,1.0]#[1.0, 1.0]
-                uparsp = [0.0,0.0]#[0.0, 0.0]
-                vthsp = [sqrt(0.5/msp[1]), sqrt(0.5/msp[2])]#[sqrt(0.01/msp[1]), sqrt(0.01/msp[2])]
-                nsprime = size(msp,1)
-                nuref = 1.0/16.0
-
-                for ivperp in 1:vperp.n
-                    for ivpa in 1:vpa.n
-                        Fs_M[ivpa,ivperp] = F_Maxwellian(dens,upar,vth,vpa,vperp,ivpa,ivperp)
-                        C_M_exact[ivpa,ivperp] = 0.0
-                    end
-                end
-                # sum up contributions to cross-collision operator
-                for isp in 1:nsprime
-                    nussp = nuref
-                    for ivperp in 1:vperp.n
-                        for ivpa in 1:vpa.n
-                            C_M_exact[ivpa,ivperp] += Cssp_Maxwellian_inputs(dens,upar,vth,mref,Zref,
-                                                                            denssp[isp],uparsp[isp],vthsp[isp],msp[isp],Zsp[isp],
-                                                                            nussp,vpa,vperp,ivpa,ivperp)
-                        end
-                    end
-                end
-                fokker_planck_cross_species_collision_operator_Maxwellian_Fsp!(C_M_num,Fs_M,
-                                     nuref,mref,Zref,msp,Zsp,denssp,uparsp,vthsp,
-                                     fkpl_arrays;
-                                     use_conserving_corrections=test_numerical_conserving_terms)
-                C_M_max, C_M_L2 = print_test_data(C_M_exact,C_M_num,C_M_err,"C_M",vpa,vperp,dummy_array,print_to_screen=print_to_screen)
-                atol_max = 1.0e-3
-                atol_L2 = 2.0e-5
-                @test C_M_max < atol_max
-                @test C_M_L2 < atol_L2
-                if !test_numerical_conserving_terms
-                    delta_n = get_density(C_M_num, vpa, vperp)
-                    rtol, atol = 0.0, 1.0e-12
-                    @test isapprox(delta_n, rtol ; atol=atol)
-                    if print_to_screen
-                        println("delta_n: ", delta_n)
-                    end
-                elseif test_numerical_conserving_terms
-                    delta_n = get_density(C_M_num, vpa, vperp)
-                    rtol, atol = 0.0, 1.0e-15
-                    @test isapprox(delta_n, rtol ; atol=atol)
-                    if print_to_screen
-                        println("delta_n: ", delta_n)
-                    end
-                end
-            end
-
+            slowing_down_fokker_planck_collisions_test(; pdf_input=false)
+            slowing_down_fokker_planck_collisions_test(; pdf_input=true)
         end
 
         @testset "weak-form (multi-species) collision operator calculation" begin

--- a/test/fokker_planck_tests.jl
+++ b/test/fokker_planck_tests.jl
@@ -17,7 +17,6 @@ using FokkerPlanck.fokker_planck_calculus: direct_integration, multipole_expansi
 
 using FokkerPlanck: fokker_plack_backward_euler_data, fokker_planck_collision_operator_weak_form!
 using FokkerPlanck: conserving_corrections!, species_info, fixed_background_plasma_input
-using FokkerPlanck: fokker_planck_cross_species_collision_operator_Maxwellian_Fsp!
 using FokkerPlanck: fokker_planck_collisions_backward_euler_step!, calculate_entropy_production
 using FokkerPlanck.fokker_planck_test: print_test_data, fkpl_error_data, allocate_error_data #, plot_test_data
 using FokkerPlanck.fokker_planck_test: F_Maxwellian, G_Maxwellian, H_Maxwellian, F_Beam

--- a/test/fokker_planck_tests.jl
+++ b/test/fokker_planck_tests.jl
@@ -675,11 +675,12 @@ function slowing_down_fokker_planck_collisions_test(;
     ngrid = 9,
     nelement_vpa = 16,
     nelement_vperp = 8,
-    pdf_input=false,
+    bc = natural_boundary_condition,
+    multi_species_operator_option = single_assembly_per_species,
     print_to_screen=false)
     vpa, vperp = create_grids(ngrid,nelement_vpa,nelement_vperp,
-                                Lvpa=12.0,Lvperp=6.0,bc_vpa=natural_boundary_condition,
-                                bc_vperp=natural_boundary_condition)
+                                Lvpa=12.0,Lvperp=6.0,bc_vpa=bc,
+                                bc_vperp=bc)
     boundary_data_option=multipole_expansion
     species = species_info([1.0], # mass of evolved species
                             [2.0]) # Z of evolved species
@@ -690,26 +691,27 @@ function slowing_down_fokker_planck_collisions_test(;
     denssp = [1.0,1.0]#[1.0, 1.0]
     uparsp = [0.0,0.0]#[0.0, 0.0]
     vthsp = [sqrt(0.5/msp[1]), sqrt(0.5/msp[2])]#[sqrt(0.01/msp[1]), sqrt(0.01/msp[2])]
-    if pdf_input
-        nsprime = length(msp)
-        Fsp_M = allocate_float(vpa.n,vperp.n,nsprime)
-        for isp in 1:nsprime
-            for ivperp in 1:vperp.n
-                for ivpa in 1:vpa.n
-                    Fsp_M[ivpa,ivperp,isp] = F_Maxwellian(denssp[isp],uparsp[isp],vthsp[isp],vpa,vperp,ivpa,ivperp)
+
+    @testset "multi_species_operator_option=$multi_species_operator_option bc=$bc pdf_input=$(pdf_input)" for pdf_input in (true,false)
+        println("        - multi_species_operator_option=$multi_species_operator_option bc=$bc pdf_input=$pdf_input")
+        if pdf_input
+            nsprime = length(msp)
+            Fsp_M = allocate_float(vpa.n,vperp.n,nsprime)
+            for isp in 1:nsprime
+                for ivperp in 1:vperp.n
+                    for ivpa in 1:vpa.n
+                        Fsp_M[ivpa,ivperp,isp] = F_Maxwellian(denssp[isp],uparsp[isp],vthsp[isp],vpa,vperp,ivpa,ivperp)
+                    end
                 end
             end
+            fixed_background_plasma_in = fixed_background_plasma_input(msp,Zsp,Fsp_M)
+        else
+            fixed_background_plasma_in = fixed_background_plasma_input(msp,Zsp,denssp,uparsp,vthsp)
         end
-        fixed_background_plasma_in = fixed_background_plasma_input(msp,Zsp,Fsp_M)
-    else
-        fixed_background_plasma_in = fixed_background_plasma_input(msp,Zsp,denssp,uparsp,vthsp)
-    end
-    fkpl_arrays = fokkerplanck_weakform_arrays_struct(vpa,vperp,species,boundary_data_option,
-                            print_to_screen=print_to_screen,
-                            fixed_background_plasma_in=fixed_background_plasma_in)
-
-    @testset "test_numerical_conserving_terms=$test_numerical_conserving_terms pdf_input=$(pdf_input)" for test_numerical_conserving_terms in (true,false)
-        println("        - test_numerical_conserving_terms=$test_numerical_conserving_terms pdf_input=$(pdf_input)")
+        fkpl_arrays = fokkerplanck_weakform_arrays_struct(vpa,vperp,species,boundary_data_option,
+                                multi_species_operator_option=multi_species_operator_option,
+                                print_to_screen=print_to_screen,
+                                fixed_background_plasma_in=fixed_background_plasma_in)
         dummy_array = allocate_float(vpa.n,vperp.n)
         Fs_M = allocate_float(vpa.n,vperp.n,species.n)
         C_M_num = allocate_float(vpa.n,vperp.n,species.n)
@@ -755,28 +757,31 @@ function slowing_down_fokker_planck_collisions_test(;
                 end
             end
         end
-        fokker_planck_collision_operator_weak_form!(
-                    C_M_num,Fs_M,nuref,fkpl_arrays;
-                    use_conserving_corrections=test_numerical_conserving_terms)
-        for is in 1:species.n
-            @views C_M_max, C_M_L2 = print_test_data(C_M_exact[:,:,is],C_M_num[:,:,is],C_M_err,"C_M",vpa,vperp,dummy_array,print_to_screen=print_to_screen)
-            atol_max = 5.0e-6
-            atol_L2 = 5.0e-8
-            @test C_M_max < atol_max
-            @test C_M_L2 < atol_L2
-            if !test_numerical_conserving_terms
-                @views delta_n = get_density(C_M_num[:,:,is], vpa, vperp)
-                rtol, atol = 0.0, 1.0e-12
-                @test isapprox(delta_n, rtol ; atol=atol)
-                if print_to_screen
-                    println("delta_n: ", delta_n)
-                end
-            elseif test_numerical_conserving_terms
-                @views delta_n = get_density(C_M_num[:,:,is], vpa, vperp)
-                rtol, atol = 0.0, 3.0e-14
-                @test isapprox(delta_n, rtol ; atol=atol)
-                if print_to_screen
-                    println("delta_n: ", delta_n)
+        @testset "test_numerical_conserving_terms=$test_numerical_conserving_terms" for test_numerical_conserving_terms in (true,false)
+            println("           - test_numerical_conserving_terms=$test_numerical_conserving_terms")
+            fokker_planck_collision_operator_weak_form!(
+                        C_M_num,Fs_M,nuref,fkpl_arrays;
+                        use_conserving_corrections=test_numerical_conserving_terms)
+            for is in 1:species.n
+                @views C_M_max, C_M_L2 = print_test_data(C_M_exact[:,:,is],C_M_num[:,:,is],C_M_err,"C_M",vpa,vperp,dummy_array,print_to_screen=print_to_screen)
+                atol_max = 5.0e-6
+                atol_L2 = 5.0e-8
+                @test C_M_max < atol_max
+                @test C_M_L2 < atol_L2
+                if !test_numerical_conserving_terms
+                    @views delta_n = get_density(C_M_num[:,:,is], vpa, vperp)
+                    rtol, atol = 0.0, 1.0e-12
+                    @test isapprox(delta_n, rtol ; atol=atol)
+                    if print_to_screen
+                        println("delta_n: ", delta_n)
+                    end
+                elseif test_numerical_conserving_terms
+                    @views delta_n = get_density(C_M_num[:,:,is], vpa, vperp)
+                    rtol, atol = 0.0, 3.0e-14
+                    @test isapprox(delta_n, rtol ; atol=atol)
+                    if print_to_screen
+                        println("delta_n: ", delta_n)
+                    end
                 end
             end
         end
@@ -1199,8 +1204,12 @@ function runtests()
 
         @testset "weak-form (slowing-down) collision operator calculation" begin
             println("    - test weak-form (slowing-down) collision operator calculation")
-            slowing_down_fokker_planck_collisions_test(; pdf_input=false)
-            slowing_down_fokker_planck_collisions_test(; pdf_input=true)
+            slowing_down_fokker_planck_collisions_test(;
+                bc = natural_boundary_condition,
+                multi_species_operator_option = single_assembly_per_species)
+            slowing_down_fokker_planck_collisions_test(;
+                bc = zero_boundary_condition,
+                multi_species_operator_option = repeat_assembly_per_species)
         end
 
         @testset "weak-form (multi-species) collision operator calculation" begin


### PR DESCRIPTION
Changes to permit the addition of a fixed background species, described by either moments of Maxwellian distribution function or a distribution function given on `(vpa, vperp)`  collocation points.  The inputs required for the fixed background species are supplied through an interface as below.
https://github.com/moment-kinetics/FokkerPlanck/blob/691d1752e61586a307723c6f8c27f072a55fbd2a/test/fokker_planck_tests.jl#L696-L713

Multiple background species are permitted.  The fixed background species Rosenbluth potentials, which contribute to the collision operator calculation for the evolved species, are computed at initialisation. At present, these Rosenbluth potentials And fixed background species information may not be updated through an interface.

In addition:
 - update tests,
 - remove unused code,
 - and update some documentation strings.

